### PR TITLE
Allow multiple hostnames, comma-separated

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ simple, easy to use, reverse proxy that can be used to front web applications.
 
 The reverse proxy is configured via environment variables. The following variables are supported:
 
-| Variable       | Description                                                | Example                 |
-|----------------|------------------------------------------------------------|-------------------------|
-| `PROXY_HOST`   | The host the proxy is listening on. Used with letsencrypt. | `example.com`           |
-| `PROXY_EMAIL`  | The email address to register with letsencrypt.            | `mail@example.com`      |
-| `PROXY_TARGET` | The target URL to proxy requests to.                       | `http://localhost:8080` |
+| Variable       | Description                                                 | Example                       |
+|----------------|-------------------------------------------------------------|-------------------------------|
+| `PROXY_HOST`   | The hostname(s) the proxy is listening on, comma-separated. | `example.com,www.example.com` |
+| `PROXY_EMAIL`  | The email address to register with letsencrypt.             | `mail@example.com`            |
+| `PROXY_TARGET` | The target URL to proxy requests to.                        | `http://localhost:8080`       |
 
 
 ## Usage

--- a/main.go
+++ b/main.go
@@ -2,13 +2,15 @@ package main
 
 import (
 	"fmt"
-	"golang.org/x/crypto/acme/autocert"
 	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"strings"
 	"time"
+
+	"golang.org/x/crypto/acme/autocert"
 )
 
 const (
@@ -43,6 +45,7 @@ func main() {
 	if host == "" {
 		log.Fatal("PROXY_HOST environment variable not set")
 	}
+	hosts := strings.Split(host, ",")
 
 	email := os.Getenv("PROXY_EMAIL")
 	if email == "" {
@@ -54,7 +57,7 @@ func main() {
 		Cache:      autocert.DirCache("autocert"),
 		Prompt:     autocert.AcceptTOS,
 		Email:      email,
-		HostPolicy: autocert.HostWhitelist(host),
+		HostPolicy: autocert.HostWhitelist(hosts...),
 	}
 
 	// Have autocert listen on port 80 to handle HTTP-01 challenges. This will also take care of redirecting


### PR DESCRIPTION
It will automatically get certificates for any host in the comma-separated
$PROXY_HOST whitelist when it receives the first request for that host.